### PR TITLE
Add zero length zipfile entry support

### DIFF
--- a/one.lfa.epubsquash.vanilla/src/main/java/one/lfa/epubsquash/vanilla/EPUBSquasher.java
+++ b/one.lfa.epubsquash.vanilla/src/main/java/one/lfa/epubsquash/vanilla/EPUBSquasher.java
@@ -274,11 +274,9 @@ final class EPUBSquasher implements EPUBSquasherType
           Files.createDirectories(temp);
         } else {
           final var parent = output_path.getParent();
-          if (parent != null) {
-            if ( ! Files.exists(parent)) {
-              LOG.debug("mkdir: {}", parent);
-              Files.createDirectories(parent);
-            }
+          if ((parent != null) && ! Files.exists(parent)) {
+            LOG.debug("mkdir: {}", parent);
+            Files.createDirectories(parent);
           }
           if (entry.getSize() == 0) {
             if ( ! Files.exists(output_path)) {

--- a/one.lfa.epubsquash.vanilla/src/main/java/one/lfa/epubsquash/vanilla/EPUBSquasher.java
+++ b/one.lfa.epubsquash.vanilla/src/main/java/one/lfa/epubsquash/vanilla/EPUBSquasher.java
@@ -280,10 +280,16 @@ final class EPUBSquasher implements EPUBSquasherType
               Files.createDirectories(parent);
             }
           }
-
-          LOG.debug("copy: {} -> {}", entry.getName(), output_path);
-          final var input = input_zip.getInputStream(entry);
-          Files.copy(input, output_path, REPLACE_EXISTING);
+          if (entry.getSize() == 0) {
+            if ( ! Files.exists(output_path)) {
+              LOG.debug("create empty: {} -> {}", entry.getName(), output_path);
+              Files.createFile(output_path);
+            }
+          } else {
+            LOG.debug("copy: {} -> {}", entry.getName(), output_path);
+            final var input = input_zip.getInputStream(entry);
+            Files.copy(input, output_path, REPLACE_EXISTING);
+          }
         }
 
         this.unpacked.put(entry.getName(), output_path);

--- a/one.lfa.epubsquash.vanilla/src/main/java/one/lfa/epubsquash/vanilla/EPUBSquasher.java
+++ b/one.lfa.epubsquash.vanilla/src/main/java/one/lfa/epubsquash/vanilla/EPUBSquasher.java
@@ -275,8 +275,10 @@ final class EPUBSquasher implements EPUBSquasherType
         } else {
           final var parent = output_path.getParent();
           if (parent != null) {
-            LOG.debug("mkdir: {}", parent);
-            Files.createDirectories(parent);
+            if ( ! Files.exists(parent)) {
+              LOG.debug("mkdir: {}", parent);
+              Files.createDirectories(parent);
+            }
           }
 
           LOG.debug("copy: {} -> {}", entry.getName(), output_path);


### PR DESCRIPTION
In cases where a zero length file has been included in the archive we can not call `input_zip.getInputStream(entry)` as it will fail with an exception. To overcome this edge case we simply check for an entry with a file size of zero and simply create an empty file as our "extracted" copy.